### PR TITLE
Check the correct field on rpc-error element

### DIFF
--- a/ncclient/operations/rpc.py
+++ b/ncclient/operations/rpc.py
@@ -306,7 +306,7 @@ class RPC(object):
                     # <rpc-error>'s [ RPCError ]
                     if self._raise_mode == RaiseMode.ALL:
                         raise self._reply.error
-                    elif (self._raise_mode == RaiseMode.ERRORS and self._reply.error.type == "error"):
+                    elif self._raise_mode == RaiseMode.ERRORS and self._reply.error.severity == "error":
                         raise self._reply.error
                 if self._device_handler.transform_reply():
                     return NCElement(self._reply, self._device_handler.transform_reply())


### PR DESCRIPTION
The RFC (https://tools.ietf.org/html/rfc6241#page-16) states that the error-type is of [transport, rpc, protocol, application] and error-severity is [error, warning] so when a request is in raise_mode "error" the code needs to check with the error-severity field instead of error-type.

Here is a new "example" modified as a test, which i test against a Juniper JunOS 11.4R1.6 :

    #! /usr/bin/env python2.6 
    #
    # Tries to changes a vlan description, but recevies the rpc error "configuration database modified"
    #
    # $ ./nc08.py broccoli VLAN2999 newname
    
    import sys
    
    import os
    import warnings
    
    warnings.simplefilter("ignore", DeprecationWarning)
    from ncclient import manager
    
    config = """<config><configuration><vlans><vlan><name>%s</name>
    <description>%s</description></vlan></vlans></configuration></config>"""
    
    def demo(host, user, vlan, new_desc):
        with manager.connect(host=host, port=22, username=user, hostkey_verify=False) as m:
            assert(":candidate" in m.server_capabilities)
    
            m.edit_config(target='candidate', config=config % (vlan, new_desc))
    
            try:
                with m.locked(target='candidate'):
                    raise Exception("The locked cannot not have been obtained, how are we here?")
            finally:
                m.discard_changes()
    
    if __name__ == '__main__':
        demo(sys.argv[1], os.getenv("USER"), sys.argv[2], sys.argv[3])
