### PR TITLE
Do not raise RPCErrors when validating config

### DIFF
--- a/ncclient/operations/edit.py
+++ b/ncclient/operations/edit.py
@@ -14,7 +14,7 @@
 
 from ncclient.xml_ import *
 
-from rpc import RPC
+from rpc import RPC, RaiseMode
 
 import util
 
@@ -120,6 +120,8 @@ class Validate(RPC):
             raise XMLError("Invalid source type: [%s], must be one of %s" % (source, tags))
         src_ele = sub_ele(node, "source")
         sub_ele(src_ele, source)
+        # We do not want to raise an error when we're validating config
+        self.raise_mode = RaiseMode.NONE
         return self._request(node)
 
 


### PR DESCRIPTION
When validating config we don't want to rise RPCErrors, we only want to report them.

This is somewhat debatable but when I'm looking for errors by doing validate, normally I want to process the information I get back. In my opinion it makes no sense to raise an Exception when doing so.

This will only work when Pull-Request #62 is merged as setting raise_mode is currently broken.

