### PR TITLE
Add check for device sending back null error_text.

### DIFF
--- a/ncclient/devices/default.py
+++ b/ncclient/devices/default.py
@@ -160,7 +160,10 @@ class DefaultDeviceHandler(object):
         Return True/False depending on found match.
 
         """
-        error_text = error_text.lower().strip()
+        if error_text != None:
+            error_text = error_text.lower().strip()
+        else:
+            error_text = 'no error given'
 
         # Compare the error text against all the exempt errors.
         for ex in self._exempt_errors_exact_match:


### PR DESCRIPTION
Some devices don't send back error_text with an RPC error. This checks to see if error_text is None and if it is sets it to reflect the lack of message. Without this check you receive an 'AttributeError' for devices not containing error_text and no helpful output to troubleshoot the actual RPC error.