### PR TITLE
manager: on connect exception, keep stacktrace

### DIFF
--- a/ncclient/manager.py
+++ b/ncclient/manager.py
@@ -117,7 +117,7 @@ def connect_ssh(*args, **kwds):
     except Exception as ex:
         if session.transport:
             session.close()
-        raise ex
+        raise
     return Manager(session, device_handler, **kwds)
 
 def connect_ioproc(*args, **kwds):


### PR DESCRIPTION
When using `raise ex`, the stack trace leading to the `ex` exception is
lost. For example, when trying to connect to a non-existant host, I get
this:

    Traceback (most recent call last):
      File "examples/nc01.py", line 21, in <module>
        demo(sys.argv[1], os.getenv("USER"))
      File "examples/nc01.py", line 16, in demo
        with manager.connect(host=host, port=22, username=user) as m:
      File "/home/bernat/code/exoscale/ncclient/ncclient/manager.py", line 147, in connect
        return connect_ssh(*args, **kwds)
      File "/home/bernat/code/exoscale/ncclient/ncclient/manager.py", line 120, in connect_ssh
        raise ex
    socket.gaierror: [Errno -2] Name or service not known

By just raising the original exception, the stacktrace is kept. For
example:

    Traceback (most recent call last):
      File "examples/nc01.py", line 21, in <module>
        demo(sys.argv[1], os.getenv("USER"))
      File "examples/nc01.py", line 16, in demo
        with manager.connect(host=host, port=22, username=user) as m:
      File "/home/bernat/code/exoscale/ncclient/ncclient/manager.py", line 147, in connect
        return connect_ssh(*args, **kwds)
      File "/home/bernat/code/exoscale/ncclient/ncclient/manager.py", line 116, in connect_ssh
        session.connect(*args, **kwds)
      File "/home/bernat/code/exoscale/ncclient/ncclient/transport/ssh.py", line 191, in connect
        for res in socket.getaddrinfo(host, port, socket.AF_UNSPEC, socket.SOCK_STREAM):
    socket.gaierror: [Errno -2] Name or service not known