### PR TITLE
ssh: enable `ssh_config=True` to default to `~/.ssh/config`

### DIFF
--- a/ncclient/transport/ssh.py
+++ b/ncclient/transport/ssh.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import sys
 import socket
 import getpass
 from binascii import hexlify
@@ -167,10 +168,12 @@ class SSHSession(Session):
 
         *look_for_keys* enables looking in the usual locations for ssh keys (e.g. :file:`~/.ssh/id_*`)
 
-        *ssh_config* enables parsing of an OpenSSH configuration file, if set to its path, e.g. ~/.ssh/config
+        *ssh_config* enables parsing of an OpenSSH configuration file, if set to its path, e.g. :file:`~/.ssh/config` or to True (in this case, use :file:`~/.ssh/config`).
         """
         # Optionaly, parse .ssh/config
         config = {}
+        if ssh_config is True:
+            ssh_config = "~/.ssh/config" if sys.platform != "win32" else "~/ssh/config"
         if ssh_config is not None:
             config = paramiko.SSHConfig()
             config.parse(open(os.path.expanduser(ssh_config)))


### PR DESCRIPTION
Instead of specifying the path to `ssh_config`, a user can just use
`True` to use the default path.