### PR TITLE
Add coveralls support, with shield in README.md

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,6 @@ python:
 install:
 - pip install .
 - pip install -r requirements.txt
-- pip install rednose coverage
+- pip install rednose coverage coveralls
 script: nosetests test --rednose --verbosity=3 --with-coverage --cover-package ncclient
+after_success: coveralls

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/leopoul/ncclient.svg?branch=master)](https://travis-ci.org/leopoul/ncclient)
+[![Coverage Status](https://coveralls.io/repos/leopoul/pyang/badge.svg)](https://coveralls.io/r/leopoul/pyang)
 [![PyPi version](https://pypip.in/v/ncclient/badge.png)](https://crate.io/packages/ncclient/)
 [![PyPi downloads](https://pypip.in/d/ncclient/badge.png)](https://crate.io/packages/ncclient/)
 [![Documentation Status](https://readthedocs.org/projects/ncclient/badge/?version=latest)](https://readthedocs.org/projects/ncclient/?badge=latest)


### PR DESCRIPTION
Quite a simple modification, as the tests already perform coverage
analysis.

I guess you'd have to create an account in https://coveralls.io/ to make this useful...