### PR TITLE
Add support for HP Comware v7 devices

### DIFF
--- a/ncclient/devices/hpcomware.py
+++ b/ncclient/devices/hpcomware.py
@@ -1,6 +1,7 @@
 from ncclient.xml_ import BASE_NS_1_0
 from .default import DefaultDeviceHandler
-from ncclient.operations.third_party.hpcomware.rpc import CLICommand
+from ncclient.operations.third_party.hpcomware.rpc import DisplayCommand
+from ncclient.operations.third_party.hpcomware.rpc import ConfigCommand
 
 
 class HpcomwareDeviceHandler(DefaultDeviceHandler):
@@ -35,5 +36,6 @@ class HpcomwareDeviceHandler(DefaultDeviceHandler):
 
     def add_additional_operations(self):
         addtl = {}
-        addtl['cli_command'] = CLICommand
+        addtl['cli_display'] = DisplayCommand
+        addtl['cli_config'] = ConfigCommand
         return addtl

--- a/ncclient/devices/hpcomware.py
+++ b/ncclient/devices/hpcomware.py
@@ -1,0 +1,39 @@
+from ncclient.xml_ import BASE_NS_1_0
+from .default import DefaultDeviceHandler
+from ncclient.operations.third_party.hpcomware.rpc import CLICommand
+
+class HpcomwareDeviceHandler(DefaultDeviceHandler):
+
+    def __init__(self, device_params):
+        super(HpcomwareDeviceHandler, self).__init__(device_params)
+
+    def get_xml_base_namespace_dict(self):
+        """
+        Base namespace needs a None key.
+
+        See 'nsmap' argument for lxml's Element().
+
+        """
+        return {None: BASE_NS_1_0}
+
+    def get_xml_extra_prefix_kwargs(self):
+        """
+        Return keyword arguments per request, which are applied to Element().
+
+        Mostly, this is a dictionary containing the "nsmap" key.
+
+        See 'nsmap' argument for lxml's Element().
+
+        """
+        d = {
+                "data": "http://www.hp.com/netconf/data:1.0",
+                "config": "http://www.hp.com/netconf/config:1.0",
+                "test": "http://www.wtf.com/netconf/data:1.0"
+            }
+        d.update(self.get_xml_base_namespace_dict())
+        return {"nsmap": d}
+
+    def add_additional_operations(self):
+        addtl = {}
+        addtl['cli_command'] = CLICommand
+        return addtl

--- a/ncclient/devices/hpcomware.py
+++ b/ncclient/devices/hpcomware.py
@@ -2,6 +2,7 @@ from ncclient.xml_ import BASE_NS_1_0
 from .default import DefaultDeviceHandler
 from ncclient.operations.third_party.hpcomware.rpc import CLICommand
 
+
 class HpcomwareDeviceHandler(DefaultDeviceHandler):
 
     def __init__(self, device_params):
@@ -28,7 +29,6 @@ class HpcomwareDeviceHandler(DefaultDeviceHandler):
         d = {
                 "data": "http://www.hp.com/netconf/data:1.0",
                 "config": "http://www.hp.com/netconf/config:1.0",
-                "test": "http://www.wtf.com/netconf/data:1.0"
             }
         d.update(self.get_xml_base_namespace_dict())
         return {"nsmap": d}

--- a/ncclient/devices/hpcomware.py
+++ b/ncclient/devices/hpcomware.py
@@ -1,6 +1,6 @@
 from ncclient.xml_ import BASE_NS_1_0
 from .default import DefaultDeviceHandler
-from ncclient.operations.third_party.hpcomware.rpc import DisplayCommand, ConfigCommand, Action
+from ncclient.operations.third_party.hpcomware.rpc import DisplayCommand, ConfigCommand, Action, Rollback, Save
 
 class HpcomwareDeviceHandler(DefaultDeviceHandler):
 
@@ -37,4 +37,6 @@ class HpcomwareDeviceHandler(DefaultDeviceHandler):
         addtl['cli_display'] = DisplayCommand
         addtl['cli_config'] = ConfigCommand
         addtl['action'] = Action
+        addtl['rollback'] = Rollback
+        addtl['save'] = Save
         return addtl

--- a/ncclient/operations/third_party/hpcomware/rpc.py
+++ b/ncclient/operations/third_party/hpcomware/rpc.py
@@ -1,16 +1,23 @@
 from lxml import etree
-
 from ncclient.xml_ import *
 from ncclient.operations.rpc import RPC
 
+
 class CLICommand(RPC):
     def request(self, cmds):
+        """
+        Single Execution element is permitted.
+        cmds can be a list or single command
+        """
+
+        if isinstance(cmds, list):
+            cmd = '\n'.join(cmds)
+        elif isinstance(cmds, str) or isinstance(cmds, unicode):
+            cmd = cmds
+
         node = etree.Element(qualify('CLI', BASE_NS_1_0))
-        print node, '^^^'
 
-        for cmd in cmds:
-            etree.SubElement(node, qualify('Execution', BASE_NS_1_0)).text = cmd
-
-        print node, '***'
+        etree.SubElement(node, qualify('Execution',
+                                       BASE_NS_1_0)).text = cmd
 
         return self._request(node)

--- a/ncclient/operations/third_party/hpcomware/rpc.py
+++ b/ncclient/operations/third_party/hpcomware/rpc.py
@@ -1,0 +1,16 @@
+from lxml import etree
+
+from ncclient.xml_ import *
+from ncclient.operations.rpc import RPC
+
+class CLICommand(RPC):
+    def request(self, cmds):
+        node = etree.Element(qualify('CLI', BASE_NS_1_0))
+        print node, '^^^'
+
+        for cmd in cmds:
+            etree.SubElement(node, qualify('Execution', BASE_NS_1_0)).text = cmd
+
+        print node, '***'
+
+        return self._request(node)

--- a/ncclient/operations/third_party/hpcomware/rpc.py
+++ b/ncclient/operations/third_party/hpcomware/rpc.py
@@ -4,12 +4,10 @@ from ncclient.operations.rpc import RPC
 
 
 class DisplayCommand(RPC):
-    def request(self, cmds, push=True):
+    def request(self, cmds):
         """
         Single Execution element is permitted.
         cmds can be a list or single command
-        when push is set to True, otherwise, the element object
-        is returned
         """
 
         if isinstance(cmds, list):
@@ -21,20 +19,16 @@ class DisplayCommand(RPC):
 
         etree.SubElement(node, qualify('Execution',
                                        BASE_NS_1_0)).text = cmd
-        if push:
-            return self._request(node)
-        else:
-            return node
+
+        return self._request(node)
 
 
 class ConfigCommand(RPC):
-    def request(self, cmds, push=True):
+    def request(self, cmds):
         """
         Single Configuration element is permitted.
         cmds can be a list or single command
         commands are pushed to the switch in this method
-        when push is set to True, otherwise, the element object
-        is returned
         """
 
         if isinstance(cmds, list):
@@ -46,10 +40,9 @@ class ConfigCommand(RPC):
 
         etree.SubElement(node, qualify('Configuration',
                                        BASE_NS_1_0)).text = cmd
-        if push:
-            return self._request(node)
-        else:
-            return node
+
+        return self._request(node)
+
 
 class Action(RPC):
     def request(self, action=None):

--- a/ncclient/operations/third_party/hpcomware/rpc.py
+++ b/ncclient/operations/third_party/hpcomware/rpc.py
@@ -9,7 +9,6 @@ class DisplayCommand(RPC):
         Single Execution element is permitted.
         cmds can be a list or single command
         """
-
         if isinstance(cmds, list):
             cmd = '\n'.join(cmds)
         elif isinstance(cmds, str) or isinstance(cmds, unicode):
@@ -48,4 +47,18 @@ class Action(RPC):
     def request(self, action=None):
         node = new_ele("action")
         node.append(validated_element(action))
+        return self._request(node)
+
+
+class Save(RPC):
+    def request(self, filename=None):
+        node = new_ele('save')
+        sub_ele(node, 'file').text = filename
+        return self._request(node)
+
+
+class Rollback(RPC):
+    def request(self, filename=None):
+        node = new_ele('rollback')
+        sub_ele(node, 'file').text = filename
         return self._request(node)

--- a/ncclient/operations/third_party/hpcomware/rpc.py
+++ b/ncclient/operations/third_party/hpcomware/rpc.py
@@ -4,11 +4,14 @@ from ncclient.operations.rpc import RPC
 
 
 class CLICommand(RPC):
-    def request(self, cmds):
+    def request(self, cmds, cmd_type=None):
         """
-        Single Execution element is permitted.
+        Single Execution/Configuration element is permitted.
+        Execution is used for display commands while
+        Configuration is used for config (system-view) commands
         cmds can be a list or single command
         """
+        NETCONFBASE_C = "{urn:ietf:params:xml:ns:netconf:base:1.0}"
 
         if isinstance(cmds, list):
             cmd = '\n'.join(cmds)
@@ -17,7 +20,23 @@ class CLICommand(RPC):
 
         node = etree.Element(qualify('CLI', BASE_NS_1_0))
 
-        etree.SubElement(node, qualify('Execution',
-                                       BASE_NS_1_0)).text = cmd
+        if cmd_type == 'display':
+            etree.SubElement(node, qualify('Execution',
+                                           BASE_NS_1_0)).text = cmd
+            response = self._request(node)
+            xml_resp = etree.fromstring(response.xml)
+            text = xml_resp.find('.//{0}Execution'.format(NETCONFBASE_C)).text
 
-        return self._request(node)
+        elif cmd_type == 'config':
+            etree.SubElement(node, qualify('Configuration',
+                                           BASE_NS_1_0)).text = cmd
+
+            response = self._request(node)
+            xml_resp = etree.fromstring(response.xml)
+            text = xml_resp.find('.//{0}Configuration'.format(NETCONFBASE_C)).text
+
+        if text:
+            text = text.replace('\n\n\n', '\n')
+            text = text.replace('\n\n', '\n')
+
+        return text

--- a/ncclient/operations/third_party/hpcomware/rpc.py
+++ b/ncclient/operations/third_party/hpcomware/rpc.py
@@ -4,11 +4,12 @@ from ncclient.operations.rpc import RPC
 
 
 class DisplayCommand(RPC):
-    def request(self, cmds):
+    def request(self, cmds, push=True):
         """
         Single Execution element is permitted.
         cmds can be a list or single command
-        commands are pushed to the switch in this method
+        when push is set to True, otherwise, the element object
+        is returned
         """
 
         if isinstance(cmds, list):
@@ -20,7 +21,10 @@ class DisplayCommand(RPC):
 
         etree.SubElement(node, qualify('Execution',
                                        BASE_NS_1_0)).text = cmd
-        return self._request(node)
+        if push:
+            return self._request(node)
+        else:
+            return node
 
 
 class ConfigCommand(RPC):


### PR DESCRIPTION
re: `ncclient/operations/third_party/hpcomware/rpc.py`

Added a custom operation to allow sending CLI commands to HP Comware devices

re: ncclient/devices/hpcomware.py

I have a question on the `get_xml_extra_prefix_kwargs`.  While what I have here works, after some testing, I can added totally bogus namespaces here, and they work, and are always returned in the netconf reply.  Would you mind providing a little more context to these k/v pairs?

Thanks.